### PR TITLE
Fix a couple bugs.

### DIFF
--- a/tf-job-operator-chart/values.yaml
+++ b/tf-job-operator-chart/values.yaml
@@ -1,5 +1,5 @@
 # Docker image to use.
-image: gcr.io/tf-on-k8s-dogfood/tf_operator:dc944ff-dirty-ff4aa6c
+image: gcr.io/tf-on-k8s-dogfood/tf_operator:8b3812d
 test_image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
 
 


### PR DESCRIPTION
* If a job can't be constructed because it fails validation the job should
  be marked as failed and the reason set to an appropriate error.

  * We do this by modifying initJob to update the status if there is a problem
    initializing the job.

* replicaStatusFromPodList needs to take into account the state where
  a container is running and there is no lastTerminationState.

  * Otherwise we get log spam complaining about no tensorflow container
    found in the running state.

* Clean up some log spam.