### PR TITLE
Set default values for Replicas, TfPort, TfReplicaType.

### DIFF
--- a/examples/tf_job.yaml
+++ b/examples/tf_job.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   replicaSpecs:
     - replicas: 1
-      tfPort: 2222
       tfReplicaType: MASTER
       template:
         spec:
@@ -14,7 +13,6 @@ spec:
               name: tensorflow
           restartPolicy: OnFailure
     - replicas: 1
-      tfPort: 2222
       tfReplicaType: WORKER
       template:
         spec:

--- a/examples/tf_job_defaults.yaml
+++ b/examples/tf_job_defaults.yaml
@@ -1,0 +1,14 @@
+# This template is used to verify that REPLICAS, TfPort, and TfReplicaType are properly set to default
+# values if unspecified by the user.
+apiVersion: "mlkube.io/v1beta1"
+kind: "TfJob"
+metadata:
+  name: "example-job-defaults"
+spec:
+  replicaSpecs:
+    - template:
+        spec:
+          containers:
+            - image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
+              name: tensorflow
+          restartPolicy: OnFailure

--- a/examples/tf_job_gpu.yaml
+++ b/examples/tf_job_gpu.yaml
@@ -4,9 +4,7 @@ metadata:
   name: "tf-smoke-gpu"
 spec:
   replicaSpecs:
-    - replicas: 1
-      tfPort: 2222
-      tfReplicaType: MASTER
+    - tfReplicaType: MASTER
       template:
         spec:
           containers:

--- a/pkg/spec/tf_job_test.go
+++ b/pkg/spec/tf_job_test.go
@@ -231,3 +231,57 @@ func TestAddAccelertor(t *testing.T) {
 		}
 	}
 }
+
+func TestSetDefaults(t *testing.T) {
+	type testCase struct {
+		in       *TfJobSpec
+		expected *TfJobSpec
+	}
+
+	testCases := []testCase{
+		{
+			in: &TfJobSpec{
+				ReplicaSpecs: []*TfReplicaSpec{
+					{
+						Template: &v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "tensorflow",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &TfJobSpec{
+				ReplicaSpecs: []*TfReplicaSpec{
+					{
+						Replicas: proto.Int32(1),
+						TfPort:   proto.Int32(2222),
+						Template: &v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "tensorflow",
+									},
+								},
+							},
+						},
+						TfReplicaType: MASTER,
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		if err := c.in.SetDefaults(); err != nil {
+			t.Errorf("SetDefaults error; %v", err)
+		}
+		if !reflect.DeepEqual(c.in, c.expected) {
+			t.Errorf("Want\n%v; Got\n %v", util.Pformat(c.expected), util.Pformat(c.in))
+		}
+	}
+}

--- a/pkg/trainer/training_test.go
+++ b/pkg/trainer/training_test.go
@@ -87,19 +87,43 @@ func TestClusterSpec(t *testing.T) {
 						{
 							Replicas:      proto.Int32(2),
 							TfPort:        proto.Int32(22),
-							Template:      &v1.PodTemplateSpec{},
+							Template:      &v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name: "tensorflow",
+										},
+									},
+								},
+							},
 							TfReplicaType: spec.PS,
 						},
 						{
 							Replicas:      proto.Int32(1),
 							TfPort:        proto.Int32(42),
-							Template:      &v1.PodTemplateSpec{},
+							Template:      &v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name: "tensorflow",
+										},
+									},
+								},
+							},
 							TfReplicaType: spec.MASTER,
 						},
 						{
 							Replicas:      proto.Int32(3),
 							TfPort:        proto.Int32(40),
-							Template:      &v1.PodTemplateSpec{},
+							Template:      &v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name: "tensorflow",
+										},
+									},
+								},
+							},
 							TfReplicaType: spec.WORKER,
 						},
 					},
@@ -125,6 +149,10 @@ func TestClusterSpec(t *testing.T) {
 
 		if err != nil {
 			t.Fatalf("initJob failed: %v", err)
+		}
+
+		if err := job.setup(&spec.ControllerConfig{}); err != nil {
+			t.Fatalf("job.setup() failed: %v", err)
 		}
 
 		actual := job.ClusterSpec()

--- a/tf-job-operator-chart/values.yaml
+++ b/tf-job-operator-chart/values.yaml
@@ -1,5 +1,5 @@
 # Docker image to use.
-image: gcr.io/tf-on-k8s-dogfood/tf_operator:8b3812d
+image: gcr.io/tf-on-k8s-dogfood/tf_operator:4dd012d
 test_image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
 
 


### PR DESCRIPTION
* Default values are set before calling validation so that validation will
  be applied to defaults.

* Picked a random value (2222) as the default port.

* Move creation of TFReplicaSet out of initJob and into TrainingJob.setup.

  This is needed because we need to call SetDefaults before creating the TfReplicaSet since SetDefaults sets the default value for number of replicas.

* Update the image used by the chart.