### PR TITLE
support multi namespaces

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -146,21 +146,21 @@ func (c *Controller) handleTfJobEvent(event *Event) error {
 		//NewJob(kubeCli kubernetes.Interface, job spec.TfJob, stopC <-chan struct{}, wg *sync.WaitGroup)
 
 		c.stopChMap[clus.Metadata.Name] = stopC
-		c.jobs[clus.Metadata.Name] = nc
+		c.jobs[clus.Metadata.Namespace + "-" + clus.Metadata.Name] = nc
 		c.jobRVs[clus.Metadata.Name] = clus.Metadata.ResourceVersion
 
 	//case kwatch.Modified:
-	//  if _, ok := c.jobs[clus.Metadata.Name]; !ok {
+	//  if _, ok := c.jobs[clus.Metadata.Namespace + "-" + clus.Metadata.Name]; !ok {
 	//    return fmt.Errorf("unsafe state. cluster was never created but we received event (%s)", event.Type)
 	//  }
-	//  c.jobs[clus.Metadata.Name].Update(clus)
+	//  c.jobs[clus.Metadata.Namespace + "-" + clus.Metadata.Name].Update(clus)
 	//  c.jobRVs[clus.Metadata.Name] = clus.Metadata.ResourceVersion
 	//
 	case kwatch.Deleted:
-		if _, ok := c.jobs[clus.Metadata.Name]; !ok {
+		if _, ok := c.jobs[clus.Metadata.Namespace + "-" + clus.Metadata.Name]; !ok {
 			return fmt.Errorf("unsafe state. TfJob was never created but we received event (%s)", event.Type)
 		}
-		c.jobs[clus.Metadata.Name].Delete()
+		c.jobs[clus.Metadata.Namespace + "-" + clus.Metadata.Name].Delete()
 		delete(c.jobs, clus.Metadata.Name)
 		delete(c.jobRVs, clus.Metadata.Name)
 	}
@@ -193,7 +193,7 @@ func (c *Controller) findAllTfJobs() (string, error) {
 			continue
 		}
 		c.stopChMap[clus.Metadata.Name] = stopC
-		c.jobs[clus.Metadata.Name] = nc
+		c.jobs[clus.Metadata.Namespace + "-" + clus.Metadata.Name] = nc
 		c.jobRVs[clus.Metadata.Name] = clus.Metadata.ResourceVersion
 	}
 

--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -111,7 +111,7 @@ func (s *TFReplicaSet) Create() error {
 		}
 
 		log.Infof("Creating Service: %v", service.ObjectMeta.Name)
-		_, err := s.ClientSet.CoreV1().Services(NAMESPACE).Create(service)
+		_, err := s.ClientSet.CoreV1().Services(s.Job.job.Metadata.Namespace).Create(service)
 
 		// If the job already exists do nothing.
 		if err != nil {
@@ -183,7 +183,7 @@ func (s *TFReplicaSet) Create() error {
 		}
 
 		log.Infof("Creating Job: %v", newJ.ObjectMeta.Name)
-		_, err = s.ClientSet.BatchV1().Jobs(NAMESPACE).Create(newJ)
+		_, err = s.ClientSet.BatchV1().Jobs(s.Job.job.Metadata.Namespace).Create(newJ)
 
 		// If the job already exists do nothing.
 		if err != nil {
@@ -211,7 +211,7 @@ func (s *TFReplicaSet) Delete() error {
 		LabelSelector: selector,
 	}
 
-	err = s.ClientSet.BatchV1().Jobs(NAMESPACE).DeleteCollection(&meta_v1.DeleteOptions{}, options)
+	err = s.ClientSet.BatchV1().Jobs(s.Job.job.Metadata.Namespace).DeleteCollection(&meta_v1.DeleteOptions{}, options)
 
 	if err != nil {
 		log.Errorf("There was a problem deleting the jobs; %v", err)
@@ -219,7 +219,7 @@ func (s *TFReplicaSet) Delete() error {
 	}
 
 	// We need to delete the completed pods.
-	err = s.ClientSet.CoreV1().Pods(NAMESPACE).DeleteCollection(&meta_v1.DeleteOptions{}, options)
+	err = s.ClientSet.CoreV1().Pods(s.Job.job.Metadata.Namespace).DeleteCollection(&meta_v1.DeleteOptions{}, options)
 
 	if err != nil {
 		log.Errorf("There was a problem deleting the pods; %v", err)
@@ -228,7 +228,7 @@ func (s *TFReplicaSet) Delete() error {
 
 	// Services doesn't support DeleteCollection so we delete them individually.
 	for index := int32(0); index < *s.Spec.Replicas; index++ {
-		err = s.ClientSet.CoreV1().Services(NAMESPACE).Delete(s.jobName(index), &meta_v1.DeleteOptions{})
+		err = s.ClientSet.CoreV1().Services(s.Job.job.Metadata.Namespace).Delete(s.jobName(index), &meta_v1.DeleteOptions{})
 
 		if err != nil {
 			log.Errorf("Error deleting service %v; %v", s.jobName(index), err)
@@ -320,7 +320,7 @@ func (s *TFReplicaSet) GetStatus() (spec.TfReplicaStatus, error) {
 
 	for index := int32(0); index < *s.Spec.Replicas; index++ {
 
-		j, err := s.ClientSet.BatchV1().Jobs(NAMESPACE).Get(s.jobName(index), meta_v1.GetOptions{})
+		j, err := s.ClientSet.BatchV1().Jobs(s.Job.job.Metadata.Namespace).Get(s.jobName(index), meta_v1.GetOptions{})
 
 		if err != nil {
 			increment(spec.ReplicaStateUnknown)
@@ -342,7 +342,7 @@ func (s *TFReplicaSet) GetStatus() (spec.TfReplicaStatus, error) {
 		}
 
 		// TODO(jlewi): Handle errors. We need to get the pod and looking at recent container exits.
-		l, err := s.ClientSet.CoreV1().Pods(NAMESPACE).List(meta_v1.ListOptions{
+		l, err := s.ClientSet.CoreV1().Pods(s.Job.job.Metadata.Namespace).List(meta_v1.ListOptions{
 			// TODO(jlewi): Why isn't the label selector working?
 			LabelSelector: selector,
 		})

--- a/pkg/trainer/replicas_test.go
+++ b/pkg/trainer/replicas_test.go
@@ -63,7 +63,7 @@ func TestTFReplicaSet(t *testing.T) {
 		}
 
 		// Check that a service was created.
-		sList, err := clientSet.CoreV1().Services(NAMESPACE).List(meta_v1.ListOptions{})
+		sList, err := clientSet.CoreV1().Services(replica.Job.job.Metadata.Namespace).List(meta_v1.ListOptions{})
 		if err != nil {
 			t.Fatalf("List services error; %v", err)
 		}
@@ -84,7 +84,7 @@ func TestTFReplicaSet(t *testing.T) {
 		}
 
 		// Check that a job was created.
-		l, err := clientSet.BatchV1().Jobs(NAMESPACE).List(meta_v1.ListOptions{})
+		l, err := clientSet.BatchV1().Jobs(replica.Job.job.Metadata.Namespace).List(meta_v1.ListOptions{})
 		if err != nil {
 			t.Fatalf("List jobs error; %v", err)
 		}

--- a/pkg/trainer/tensorboard.go
+++ b/pkg/trainer/tensorboard.go
@@ -67,7 +67,7 @@ func (s *TBReplicaSet) Create() error {
 	}
 
 	log.Infof("Creating Service: %v", service.ObjectMeta.Name)
-	_, err := s.ClientSet.CoreV1().Services(NAMESPACE).Create(service)
+	_, err := s.ClientSet.CoreV1().Services(s.Job.job.Metadata.Namespace).Create(service)
 
 	// If the job already exists do nothing.
 	if err != nil {
@@ -93,7 +93,7 @@ func (s *TBReplicaSet) Create() error {
 	}
 
 	log.Infof("Creating Deployment: %v", newD.ObjectMeta.Name)
-	_, err = s.ClientSet.ExtensionsV1beta1().Deployments(NAMESPACE).Create(newD)
+	_, err = s.ClientSet.ExtensionsV1beta1().Deployments(s.Job.job.Metadata.Namespace).Create(newD)
 
 	if err != nil {
 		if k8s_errors.IsAlreadyExists(err) {
@@ -109,7 +109,7 @@ func (s *TBReplicaSet) Delete() error {
 	failures := false
 
 	delProp := meta_v1.DeletePropagationForeground
-	err := s.ClientSet.ExtensionsV1beta1().Deployments(NAMESPACE).Delete(s.jobName(), &meta_v1.DeleteOptions{
+	err := s.ClientSet.ExtensionsV1beta1().Deployments(s.Job.job.Metadata.Namespace).Delete(s.jobName(), &meta_v1.DeleteOptions{
 		PropagationPolicy: &delProp,
 	})
 	if err != nil {
@@ -117,7 +117,7 @@ func (s *TBReplicaSet) Delete() error {
 		failures = true
 	}
 
-	err = s.ClientSet.CoreV1().Services(NAMESPACE).Delete(s.jobName(), &meta_v1.DeleteOptions{})
+	err = s.ClientSet.CoreV1().Services(s.Job.job.Metadata.Namespace).Delete(s.jobName(), &meta_v1.DeleteOptions{})
 	if err != nil {
 		log.Errorf("Error deleting service: %v; %v", s.jobName(), err)
 		failures = true

--- a/pkg/trainer/tensorboard_test.go
+++ b/pkg/trainer/tensorboard_test.go
@@ -63,7 +63,7 @@ func TestTBReplicaSet(t *testing.T) {
 
 	// Check that a service was created.
 	// TODO: Change this List for a Get for clarity
-	sList, err := clientSet.CoreV1().Services(NAMESPACE).List(meta_v1.ListOptions{})
+	sList, err := clientSet.CoreV1().Services(replica.Job.job.Metadata.Namespace).List(meta_v1.ListOptions{})
 	if err != nil {
 		t.Fatalf("List services error; %v", err)
 	}
@@ -84,7 +84,7 @@ func TestTBReplicaSet(t *testing.T) {
 	}
 
 	// Check that a deployment was created.
-	l, err := clientSet.ExtensionsV1beta1().Deployments(NAMESPACE).List(meta_v1.ListOptions{})
+	l, err := clientSet.ExtensionsV1beta1().Deployments(replica.Job.job.Metadata.Namespace).List(meta_v1.ListOptions{})
 	if err != nil {
 		t.Fatalf("List deployments error; %v", err)
 	}

--- a/pkg/util/k8sutil/tpr_util.go
+++ b/pkg/util/k8sutil/tpr_util.go
@@ -75,8 +75,8 @@ func (c *TfJobRestClient) Client() *http.Client {
 }
 
 func (c *TfJobRestClient) Watch(host, ns string, httpClient *http.Client, resourceVersion string) (*http.Response, error) {
-	return c.restcli.Client.Get(fmt.Sprintf("%s/apis/%s/%s/namespaces/%s/%s?watch=true&resourceVersion=%s",
-		host, spec.CRDGroup, spec.CRDVersion, ns, spec.CRDKindPlural, resourceVersion))
+	return c.restcli.Client.Get(fmt.Sprintf("%s/apis/%s/%s/%s?watch=true&resourceVersion=%s",
+		host, spec.CRDGroup, spec.CRDVersion, spec.CRDKindPlural, resourceVersion))
 }
 
 func (c *TfJobRestClient) List(ns string) (*spec.TfJobList, error) {


### PR DESCRIPTION
If tfjob controller runs as a deployment in k8s default namespace, we can't not create tfjob crd in another namespace.This PR fix the issue.There are three major modification:

1）tf job controller should watch crd event in all namespaces.

2）tfjob controller creates/deletes training job/tensorboard in specific namespace instead of its own ns.

3）tfjob controller maintain a map from crd name to crd object.The map key should add crd namespace as prefix.