### PR TITLE
Always check for existing TfJobs and instantiate controllers for them.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -85,6 +85,7 @@ func (c *Controller) Run() error {
 	for {
 		watchVersion, err = c.initResource()
 		if err == nil {
+			log.Info("Starting watch at version %v", watchVersion)
 			break
 		}
 		log.Errorf("initialization failed: %v", err)


### PR DESCRIPTION
Fix #41 

* Whenever we start the controller, we should check if there are existing
  TfJobs and instantiate controllers for them so they aren't orphaned.

* Previously we only did this if the CRD already existed. IMO it seems
  more robust to always do it and not rely on the CRD already existing.