### PR TITLE
Fix bug that prevents permanent errors from causing job failure.

### DIFF
--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -133,6 +133,7 @@ func (s *TFReplicaSet) Create() error {
 				"index": index,
 			},
 		}
+
 		tfConfigJson, err := json.Marshal(tfConfig)
 		if err != nil {
 			log.Errorf("Job: %v serializing tfConfig: %v return error; %v", s.Job.job.Metadata.Name, util.Pformat(tfConfig), err)

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -251,15 +251,6 @@ func isRetryableTerminationState(s *v1.ContainerStateTerminated) bool {
 		return false
 	}
 
-	if s.Message == "" {
-		// launcher.sh should produce a termination log message. So if Kubernetes
-		// doesn't report a termmination message then we can infer that
-		// launcher.sh didn't exit cleanly. For example, the container might
-		// have failed to start. We consider this a retryable error regardless
-		// of the actual exit code.
-		return true
-	}
-
 	// TODO(jlewi): Should we use the exit code reported in the termination
 	// log message and not the ExitCode reported by the container.
 

--- a/pkg/trainer/training_test.go
+++ b/pkg/trainer/training_test.go
@@ -25,7 +25,7 @@ func TestIsRetryableTerminationState(t *testing.T) {
 			State: v1.ContainerStateTerminated{
 				ExitCode: 0,
 			},
-			Expected: true,
+			Expected: false,
 		},
 		{
 			State: v1.ContainerStateTerminated{
@@ -42,11 +42,10 @@ func TestIsRetryableTerminationState(t *testing.T) {
 			Expected: false,
 		},
 		{
-			// Since Reason is empty we don't trust the exit code.
 			State: v1.ContainerStateTerminated{
 				ExitCode: 1,
 			},
-			Expected: true,
+			Expected: false,
 		},
 		{
 			State: v1.ContainerStateTerminated{


### PR DESCRIPTION
* Code should not depend on the termination message being set to decide
  whether to trust exit code. This is legacy code that dependend on a
  script setting the termination message. But the CRD no longer uses
  a script to launch the TF process.

* Fixes #28 