### PR TITLE
Create symbolic links in GCS to output of presubmit results.

### DIFF
--- a/test-infra/runner_test.py
+++ b/test-infra/runner_test.py
@@ -22,5 +22,19 @@ class TestRunner(unittest.TestCase):
     blob.upload_from_string.assert_called_once_with(json.dumps(expected))
 
 
+  def testGetSymlinkOutput(self):
+    location = runner.get_symlink_output("10", "mlkube-build-presubmit", "20")
+    self.assertEquals(
+      "gs://kubernetes-jenkins/pr-logs/directory/mlkube-build-presubmit/20.txt",
+      location)
+
+  def testCreateSymlinkOutput(self):
+    """Test create started for periodic job."""
+    gcs_client = mock.MagicMock(spec=storage.Client)
+    blob = runner.create_symlink(gcs_client, "gs://bucket/symlink",
+                                 "gs://bucket/output")
+
+    blob.upload_from_string.assert_called_once_with("gs://bucket/output")
+
 if __name__ == "__main__":
   unittest.main()

--- a/test-infra/runner_test.py
+++ b/test-infra/runner_test.py
@@ -7,6 +7,20 @@ from google.cloud import storage
 
 class TestRunner(unittest.TestCase):
   @mock.patch("runner.time.time")
+  def testCreateFinished(self, mock_time):
+    """Test create finished"""
+    mock_time.return_value = 1000
+    gcs_client = mock.MagicMock(spec=storage.Client)
+    blob = runner.create_finished(gcs_client, "gs://bucket/output", True)
+
+    expected = {
+      "timestamp": 1000,
+      "result": "SUCCESS",
+      "metadata": {},
+    }
+    blob.upload_from_string.assert_called_once_with(json.dumps(expected))
+
+  @mock.patch("runner.time.time")
   def testCreateStartedPeriodic(self, mock_time):
     """Test create started for periodic job."""
     mock_time.return_value = 1000


### PR DESCRIPTION
* Presubmit tests need a symbolic link in GCS pointing to the results.
* Hopefully this will cause presubmit results to show up in test grid (issue #75)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jlewi/mlkube.io/79)
<!-- Reviewable:end -->
